### PR TITLE
PROD-27273: Add others version for PSR/Log to be compatible for D10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "bunny/bunny": "^0.4.3 || ^0.5.0",
         "cboden/ratchet": "^0.4.3",
-        "psr/log": "^1",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "webonyx/graphql-php": "^14.8"
     },
     "config": {


### PR DESCRIPTION
Added others version for PSR/Log because the Drupal 9 still require version 1.0 and Drupal 10 will require version 3.0.