### PR TITLE
Update bunny/bunny compatibility to ^0.4.3 || ^0.5.0 || ^0.6.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "bunny/bunny": "^0.4.3 || ^0.5.0",
+        "bunny/bunny": "^0.4.3 || ^0.5.0 || ^0.6.0",
         "cboden/ratchet": "^0.4.3",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "webonyx/graphql-php": "^14.8"


### PR DESCRIPTION
### Problem
To update composer/composer to. 2.9.2, we need bunny 6 branch.

### Solution
Update dependency bunny/bunny compatibility to ^0.4.3 || ^0.5.0 || ^0.6.0.